### PR TITLE
update debug logs 28/01/2021 - RIGHT

### DIFF
--- a/home.admin/XXdebugLogs.sh
+++ b/home.admin/XXdebugLogs.sh
@@ -32,13 +32,15 @@ fi
 clear
 echo ""
 echo "***************************************************************"
-echo "* RASPIBLITZ DEBUG LOGS "
+echo "* --------------- BEGIN RASPIBLITZ DEBUG LOGS --------------- *"
 echo "***************************************************************"
-echo "blitzversion: ${codeVersion}"
-echo "chainnetwork: ${network} / ${chain}"
-uptime
 echo ""
 
+echo "blitzversion: ${codeVersion}"
+echo "chainnetwork: ${network} / ${chain}"
+echo ""
+
+echo ""
 echo "*** BLOCKCHAIN SYSTEMD STATUS ***"
 sudo systemctl status ${network}d -n2 --no-pager
 echo ""
@@ -57,6 +59,7 @@ echo "sudo tail -n 20 /mnt/hdd/${network}${pathAdd}/debug.log"
 sudo tail -n 20 /mnt/hdd/${network}${pathAdd}/debug.log
 echo ""
 
+echo ""
 echo "*** LND SYSTEMD STATUS ***"
 sudo systemctl status lnd -n2 --no-pager
 echo ""
@@ -71,12 +74,14 @@ echo "sudo tail -n 30 /mnt/hdd/lnd/logs/${network}/${chain}net/lnd.log"
 sudo tail -n 30 /mnt/hdd/lnd/logs/${network}/${chain}net/lnd.log
 echo ""
 
+echo ""
 echo "*** LAST NGINX LOGS ***"
 echo "sudo journalctl -u nginx -b --no-pager -n20"
 sudo journalctl -u nginx -b --no-pager -n20
 echo "--> CHECK CONFIG: sudo nginx -t"
 sudo nginx -t
 echo ""
+
 
 if [ "${touchscreen}" = "1" ]; then
   echo ""
@@ -85,7 +90,9 @@ if [ "${touchscreen}" = "1" ]; then
   sudo tail -n 20 /home/pi/.cache/lxsession/LXDE-pi/run.log
   echo ""
 else
+  echo ""
   echo "- TOUCHSCREEN is OFF by config"
+  echo ""
 fi
 
 if [ "${loop}" = "on" ]; then
@@ -95,7 +102,9 @@ if [ "${loop}" = "on" ]; then
   sudo journalctl -u loopd -b --no-pager -n20
   echo ""
 else
+  echo ""
   echo "- Loop is OFF by config"
+  echo ""
 fi
 
 if [ "${rtlWebinterface}" = "on" ]; then
@@ -105,7 +114,9 @@ if [ "${rtlWebinterface}" = "on" ]; then
   sudo journalctl -u RTL -b --no-pager -n20
   echo ""
 else
+  echo ""
   echo "- RTL is OFF by config"
+  echo ""
 fi
 
 if [ "${ElectRS}" = "on" ]; then
@@ -118,7 +129,9 @@ if [ "${ElectRS}" = "on" ]; then
   sudo /home/admin/config.scripts/bonus.electrs.sh status
   echo ""
 else
+  echo ""
   echo "- Electrum Rust Server is OFF by config"
+  echo ""
 fi
 
 if [ "${BTCPayServer}" = "on" ]; then
@@ -128,7 +141,9 @@ if [ "${BTCPayServer}" = "on" ]; then
   sudo journalctl -u btcpayserver -b --no-pager -n20
   echo ""
 else
+  echo ""
   echo "- BTCPayServer is OFF by config"
+  echo ""
 fi
 
 if [ "${LNBits}" = "on" ]; then
@@ -138,7 +153,9 @@ if [ "${LNBits}" = "on" ]; then
   sudo journalctl -u lnbits -b --no-pager -n20
   echo ""
 else
+  echo ""
   echo "- LNbits is OFF by config"
+  echo ""
 fi
 
 if [ "${thunderhub}" = "on" ]; then
@@ -148,7 +165,9 @@ if [ "${thunderhub}" = "on" ]; then
   sudo journalctl -u thunderhub -b --no-pager -n20
   echo ""
 else
+  echo ""
   echo "- Thunderhub is OFF by config"
+  echo ""
 fi
 
 if [ "${specter}" = "on" ]; then
@@ -158,7 +177,9 @@ if [ "${specter}" = "on" ]; then
   sudo journalctl -u cryptoadvance-specter -b --no-pager -n20
   echo ""
 else
+  echo ""
   echo "- SPECTER is OFF by config"
+  echo ""
 fi
 
 if [ "${sphinxrelay}" = "on" ]; then
@@ -168,19 +189,53 @@ if [ "${sphinxrelay}" = "on" ]; then
   sudo journalctl -u sphinxrelay -b --no-pager -n20
   echo ""
 else
+  echo ""
   echo "- SPHINX is OFF by config"
+  echo ""
 fi
 
 echo ""
+echo "*** NETWORK Info ***"
+sudo /home/admin/config.scripts/internet.sh status | grep 'network_device\|localip\|dhcp'
+echo ""
+
+echo ""
 echo "*** MOUNTED DRIVES ***"
-df -T
+df -T -h
+echo ""
+
+
+# get HDD/SSD info
+source <(sudo /home/admin/config.scripts/blitz.datadrive.sh status)
+hdd="${hddUsedInfo}"
+
+# get memory
+ram_avail=$(free -m | grep Mem | awk '{ print $7 }')
+ram=$(printf "%sM / %sM" "${ram_avail}" "$(free -m | grep Mem | awk '{ print $2 }')")
+
+# get uptime & load
+## get uptime and current date & time
+uptime=$(uptime --pretty)
+datetime=$(date -R)
+load=$(w | head -n 1 | cut -d 'v' -f2 | cut -d ':' -f2)
+# get CPU temp - no measurement in a VM
+cpu=0
+if [ -d "/sys/class/thermal/thermal_zone0/" ]; then
+  cpu=$(cat /sys/class/thermal/thermal_zone0/temp)
+fi
+tempC=$((cpu/1000))
+tempF=$(((tempC * 18 + 325) / 10))
+
+echo ""
+echo "*** HARDWARE STATE ***"
+echo "date=${datetime}"
+echo "cpuLoad=${load##up*,  }"
+echo "cpuTemp= ${tempC}°C" "${tempF}°F"
+echo "freeMem= ${ram}"
+echo "usedHdd= ${hdd}"
 echo ""
 
 echo ""
-echo "*** WIFI Info ***"
-sudo /home/admin/config.scripts/internet.wifi.sh status
-echo ""
-
 echo "*** HARDWARE TEST RESULTS ***"
 showImproveInfo=0
 if [ ${#undervoltageReports} -gt 0 ]; then
@@ -205,8 +260,15 @@ if [ ${showImproveInfo} -gt 0 ]; then
 fi
 echo ""
 
+echo ""
 echo "*** SYSTEM STATUS (can take some seconds to gather) ***"
 sudo /home/admin/config.scripts/blitz.statusscan.sh
+echo ""
+
+echo ""
+echo "***************************************************************"
+echo "* ---------------- END RASPIBLITZ DEBUG LOGS ---------------- *"
+echo "***************************************************************"
 echo ""
 
 echo "*** OPTION: SHARE THIS DEBUG OUTPUT ***"


### PR DESCRIPTION
-Added the hardware informations that are only presented on status screen, but just after IBD. (line 208/235)
-BEGIN and END of debug similar to the style of PGP (lines 34/37 and 268/273)
-Changed Wifi Info to Network Info, because now it presents if its over ETH or WLAN (line 197) 
-The echo "" is to be spaced, facilitating reading the logs. If its related (bitcoin logs and bitcoin status, only 1 line of space. If its passing from bitcoin informations to lnd information, its 2 lines of spacing). Cannot say its necessary, but that made me distinct informations and find what I wanted faster.
-Mounted drives size now displayed in human readable form.
-https://github.com/rootzoll/raspiblitz/pull/1947#issuecomment-769432863